### PR TITLE
Add min_request_time field.

### DIFF
--- a/src/main/proto/messages.proto
+++ b/src/main/proto/messages.proto
@@ -51,6 +51,9 @@ message StatisticSetRecord {
     string metric = 3;
     string period = 4;
     string period_start = 5;
+    // Timestamp at which the earliest message that was aggregated into
+    // this StatisticSetRecord was recorded. Used to monitor pipeline
+    // latency.
     string client_minimum_request_time = 9;
     repeated StatisticRecord statistics = 6;
     map<string, string> dimensions = 8;

--- a/src/main/proto/messages.proto
+++ b/src/main/proto/messages.proto
@@ -51,7 +51,7 @@ message StatisticSetRecord {
     string metric = 3;
     string period = 4;
     string period_start = 5;
-    string min_request_time = 9;
+    string client_minimum_request_time = 9;
     repeated StatisticRecord statistics = 6;
     map<string, string> dimensions = 8;
 }

--- a/src/main/proto/messages.proto
+++ b/src/main/proto/messages.proto
@@ -51,6 +51,7 @@ message StatisticSetRecord {
     string metric = 3;
     string period = 4;
     string period_start = 5;
+    string min_request_time = 9;
     repeated StatisticRecord statistics = 6;
     map<string, string> dimensions = 8;
 }


### PR DESCRIPTION
This will be populated by the minimum request_millis_since_epoch time from https://github.com/InscopeMetrics/client-protocol/pull/16 that's been aggregated into the bucket to be sent to CAGG.