### PR TITLE
Revert "Bump com.google.protobuf:protobuf-java from 4.26.0 to 4.26.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <!--Dependency versions-->
-    <protobuf.version>4.26.1</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <protoc.version>4.26.0</protoc.version>
 
     <!--Plugin versions-->


### PR DESCRIPTION
Reverts ArpNetworking/metrics-aggregator-protocol#26
protobuf 4 is not ready for prime time in java land